### PR TITLE
feat(dashboard): Implement summary cards and citizen-per-city horizontal bar chart

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-APP_NAME=Laravel
+APP_NAME=CityCitizenAnalytics
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true

--- a/app/Http/Controllers/CityController.php
+++ b/app/Http/Controllers/CityController.php
@@ -38,11 +38,12 @@ class CityController extends Controller
     public function store(Request $request)
     {
         $request->validate([
-            'name' => 'required|string|max:50',
+            'name'        => 'required|string|max:50|unique:cities,name',
             'description' => 'nullable|string|max:500',
         ], [
             'name.required' => 'El nombre de la ciudad es obligatorio.',
             'name.string' => 'El nombre de la ciudad debe ser una cadena de texto.',
+            'name.unique' => 'El nombre de la ciudad ya existe.',
             'name.max' => 'El nombre de la ciudad no puede exceder los 50 caracteres.',
             'description.max' => 'La descripción no puede exceder los 500 caracteres.',
         ]);
@@ -87,8 +88,14 @@ class CityController extends Controller
     public function update(Request $request, string $id)
     {
         $request->validate([
-            'name' => 'required|string|max:50',
+            'name' => 'required|string|max:50|unique:cities,name',
             'description' => 'nullable|string|max:500',
+        ], [
+            'name.required' => 'El nombre de la ciudad es obligatorio.',
+            'name.string' => 'El nombre de la ciudad debe ser una cadena de texto.',
+            'name.unique' => 'El nombre de la ciudad ya existe.',
+            'name.max' => 'El nombre de la ciudad no puede exceder los 50 caracteres.',
+            'description.max' => 'La descripción no puede exceder los 500 caracteres.',
         ]);
 
         try {

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -13,6 +13,6 @@ class DashboardController extends Controller
         $totalCitizens = Citizen::count();
         $citizensPerCity = City::withCount('citizens')->orderBy('citizens_count', 'desc')->get();
 
-        return view('dashboard', compact('totalCities', 'totalCitizens', 'citizenPerCity'));
+        return view('dashboard', compact('totalCities', 'totalCitizens', 'citizensPerCity'));
     }
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\City;
+use App\Models\Citizen;
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    public function index(){
+        $totalCities = City::count();
+        $totalCitizens = Citizen::count();
+        $citizensPerCity = City::withCount('citizens')->orderBy('citizens_count', 'desc')->get();
+
+        return view('dashboard', compact('totalCities', 'totalCitizens', 'citizenPerCity'));
+    }
+}

--- a/resources/views/cities/_form.blade.php
+++ b/resources/views/cities/_form.blade.php
@@ -20,7 +20,7 @@
         </label>
         <input type="text" name="name" id="name" value="{{ old('name', $city->name ?? '') }}" placeholder="e.g.: Managua" class="block w-full px-4 py-2 bg-gray-100 dark:bg-gray-700  border border-gray-300 dark:border-gray-600  rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition"/>
         @error('name')
-            <span class="text-red-500 text-sm mt-1">{{ $message }}</span>
+            <span class="text-red-500 text-xs italic mt-2">{{ $message }}</span>
         @enderror
     </div>
 
@@ -31,17 +31,17 @@
         </label>
         <textarea name="description" id="description" rows="4" placeholder="Describe la ciudad..." class="block w-full px-4 py-2 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition resize-none">{{ old('description', $city->description ?? '') }}</textarea>
         @error('description')
-            <span class="text-red-500 text-sm mt-1">{{ $message }}</span>
+            <span class="text-red-500 text-xs italic mt-2">{{ $message }}</span>
         @enderror
     </div>
 
     <!-- Botón de enviar/cancelar -->
-    <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
-        <button type="submit" class="w-full sm:w-auto inline-flex justify-center items-center gap-2 px-5 py-3 bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-900 transition-all">
+    <div class="flex flex-col gap-3">
+        <button type="submit" class="w-full inline-flex justify-center items-center gap-2 px-5 py-3 bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-900 transition-all">
             <i class="fas {{ $isEdit ? 'fa-rotate' : 'fa-user-plus' }}"></i>
             {{ $isEdit ? __('Actualizar Ciudad') : __('Crear Ciudad') }}
         </button>
-        <a href="{{ route('cities.index') }}" class="w-full sm:w-auto inline-flex justify-center items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition">
+        <a href="{{ route('cities.index') }}" class="w-full inline-flex justify-center items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition">
             <i class="fas fa-arrow-left"></i>
             {{ __('Cancelar') }}
         </a>

--- a/resources/views/cities/index.blade.php
+++ b/resources/views/cities/index.blade.php
@@ -2,7 +2,7 @@
    <x-slot name="header">
         <div class="flex items-center justify-between">
             <div class="flex items-center gap-2">
-                <i class="fas fa-city text-2xl text-indigo-600 dark:text-indigo-400"></i>
+                <i class="fa-regular fa-map text-2xl text-indigo-600 dark:text-indigo-400"></i>
                 <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-100">
                     {{ __('Ciudades') }}
                 </h2>

--- a/resources/views/citizens/_form.blade.php
+++ b/resources/views/citizens/_form.blade.php
@@ -86,12 +86,12 @@
     </div>
 
     <!-- Botón de enviar/cancelar -->
-    <div class="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3">
-        <button type="submit" class="w-full sm:w-auto inline-flex justify-center items-center gap-2 px-5 py-3 bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-900 transition-all">
+    <div class="flex flex-col gap-3">
+        <button type="submit" class="w-full inline-flex justify-center items-center gap-2 px-5 py-3 bg-indigo-600 hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-900 transition-all">
             <i class="fas {{ $isEdit ? 'fa-rotate' : 'fa-user-plus' }}"></i>
             {{ $isEdit ? __('Actualizar Ciudadano') : __('Crear Ciudadano') }}
         </button>
-        <a href="{{ route('citizens.index') }}" class="w-full sm:w-auto inline-flex justify-center items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition">
+        <a href="{{ route('citizens.index') }}" class="w-full inline-flex justify-center items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition">
             <i class="fas fa-arrow-left"></i>
             {{ __('Cancelar') }}
         </a>

--- a/resources/views/citizens/index.blade.php
+++ b/resources/views/citizens/index.blade.php
@@ -2,7 +2,7 @@
     <x-slot name="header">
         <div class="flex items-center justify-between">
             <div class="flex items-center gap-2">
-                <i class="fa-solid fa-person-walking text-2xl text-indigo-600 dark:text-indigo-400"></i>
+                <i class="fas fa-users text-2xl text-indigo-600 dark:text-indigo-400"></i>
                 <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-100">
                     {{ __('Ciudadanos') }}
                 </h2>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,17 +1,39 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-            {{ __('Dashboard') }}
-        </h2>
+        <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2">
+                <i class="fa-solid fa-chart-simple text-2xl text-indigo-600 dark:text-indigo-400"></i>
+                <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-100">
+                    {{ __('Dashboard') }}
+                </h2>
+            </div>
+        </div>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 text-gray-900 dark:text-gray-100">
-                    {{ __("You're logged in!") }}
+    <div class="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-6 py-8 px-4">
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow p-6">
+            <div class="flex items-center">
+                <div class="p-3 bg-gray-100 dark:bg-gray-700 rounded-md">
+                    <i class="fa-regular fa-map text-gray-600 dark:text-gray-300 text-xl"></i>
+                </div>
+                <div class="ml-4">
+                    <p class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('Total de ciudades') }}</p>
+                    <p class="mt-1 text-4xl md:text-4xl font-extrabold text-gray-900 dark:text-white">{{ number_format($totalCities) }}</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow p-6">
+            <div class="flex items-center">
+                <div class="p-3 bg-gray-100 dark:bg-gray-700 rounded-md">
+                    <i class="fas fa-users text-gray-600 dark:text-gray-300 text-xl"></i>
+                </div>
+                <div class="ml-4">
+                    <p class="text-sm font-medium text-gray-500 dark:text-gray-400">{{ __('Total de ciudadanos') }}</p>
+                    <p class="mt-1 text-4xl md:text-4xl font-extrabold text-gray-900 dark:text-white">{{ number_format($totalCitizens) }}</p>
                 </div>
             </div>
         </div>
     </div>
+
 </x-app-layout>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -11,7 +11,7 @@
     </x-slot>
 
     <div class="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-6 py-8 px-4">
-        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow p-6">
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow p-6">
             <div class="flex items-center">
                 <div class="p-3 bg-gray-100 dark:bg-gray-700 rounded-md">
                     <i class="fa-regular fa-map text-gray-600 dark:text-gray-300 text-xl"></i>
@@ -23,7 +23,7 @@
             </div>
         </div>
 
-        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow p-6">
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow p-6">
             <div class="flex items-center">
                 <div class="p-3 bg-gray-100 dark:bg-gray-700 rounded-md">
                     <i class="fas fa-users text-gray-600 dark:text-gray-300 text-xl"></i>
@@ -36,4 +36,56 @@
         </div>
     </div>
 
+    <div class="max-w-6xl mx-auto px-4">
+        <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl shadow p-6 col-span-1 sm:col-span-2 lg:col-span-3">
+            <h3 class="text-lg font-semibold text-center text-gray-700 dark:text-gray-200 mb-4">
+                {{ __('Ciudadanos por ciudad') }}
+            </h3>
+            <canvas id="citizensChart"></canvas>
+        </div>
+    </div>
+
+@push('scripts')
+    <script>
+        const labels = @json($citizensPerCity->pluck('name'));
+        const dataCounts = @json($citizensPerCity->pluck('citizens_count'));
+
+        const config = {
+            type: 'bar',
+            data: {
+            labels: labels,
+            datasets: [{
+                label: 'Ciudadanos',
+                data: dataCounts,
+                backgroundColor: 'rgba(59, 130, 246, 0.5)',
+                borderColor: 'rgba(59, 130, 246, 1)',
+                borderWidth: 2
+            }]
+            },
+            options: {
+                indexAxis: 'y', // El grafico se dibujará en horizontal
+                elements: {
+                    bar: {
+                        borderWidth: 2,
+                        borderRadius: 2
+                    }
+                },
+                responsive: true,
+                scales: {
+                    x: {
+                        beginAtZero: true,
+                        ticks: { precision: 0 }
+                    }
+                },
+                plugins: {
+                    legend: { display: false }
+                }
+            }
+        };
+
+        // Aquí se obtiene el contexto del canvas y se crea el gráfico
+        const ctx = document.getElementById('citizensChart').getContext('2d');
+        new Chart(ctx, config);
+    </script>
+@endpush
 </x-app-layout>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,10 +10,11 @@
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
-        
-        <!-- CDNs de SweetAlert2 para diseño y manejo de ventanas emergentes, y FontAwesome para íconos -->
+
+        <!-- CDNs de SweetAlert2 para diseño y manejo de ventanas emergentes, FontAwesome para íconos y Chart.js para gráficos -->
         <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
         <script defer src="https://kit.fontawesome.com/2af02d949f.js" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
@@ -36,5 +37,6 @@
                 {{ $slot }}
             </main>
         </div>
+        @stack('scripts')
     </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,14 +4,15 @@ use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\CitizenController;
 use App\Http\Controllers\CityController;
+use App\Http\Controllers\DashboardController;
 
 Route::get('/', function () {
     return view('welcome');
 });
 
-Route::get('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('/dashboard', [DashboardController::class, 'index'])
+     ->middleware(['auth', 'verified'])
+     ->name('dashboard');
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');


### PR DESCRIPTION
The following PR completes the dashboard's requested features by:

- Adding two summary cards for total cities and total citizens
- Integrating Chart.js to render a horizontal bar chart of citizens per city
- Applying minor logic and UI tweaks across other views and controllers for consistency purposes